### PR TITLE
Enhance campaign creation validation and improve API URL handling

### DIFF
--- a/backend/src/controllers/campaignController.js
+++ b/backend/src/controllers/campaignController.js
@@ -378,7 +378,7 @@ class CampaignController {
   validateCreateCampaign(data) {
     const schema = Joi.object({
       name: Joi.string().min(3).max(200).required(),
-      description: Joi.string().min(10).max(1000).optional().allow(''),
+      description: Joi.string().max(1000).optional().allow('', null).default(''),
       image: Joi.string().optional().allow(null, ''),
       organizer: Joi.string().pattern(/^0x[a-fA-F0-9]{40}$/).required(),
       deadline: Joi.number().integer().min(Math.floor(Date.now() / 1000)).required(),

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,4 +1,4 @@
-const BASE = import.meta.env.VITE_BACKEND_URL
+const BASE = import.meta.env.VITE_BACKEND_URL || ''
 const API_PREFIX = '/api'
 
 // Build url structure (e.g. http://localhost:3001/api/campaigns)
@@ -6,6 +6,13 @@ const isAbsolute = (p) => /^https?:\/\//i.test(p)
 const buildUrl = (path) => {
   if (isAbsolute(path)) return path
   const safePath = path.startsWith('/') ? path : `/${path}`
+
+  // If BASE is empty, use Vite proxy (just /api/path)
+  if (!BASE) {
+    return `${API_PREFIX}${safePath}`
+  }
+
+  // Otherwise use full URL (BASE/api/path)
   return `${BASE}${API_PREFIX}${safePath}`
 }
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        secure: false,
+      }
+    }
+  }
 })


### PR DESCRIPTION
This pull request introduces improvements to both the frontend and backend to enhance API connectivity and data validation. The frontend now gracefully handles situations where the backend URL is not set, defaulting to a proxy configuration for local development, while the backend improves campaign creation validation for the `description` field.

**Frontend API connectivity improvements:**

* Updated `frontend/src/lib/api.js` to use a fallback proxy route when `VITE_BACKEND_URL` is not set, ensuring API calls work seamlessly in local development environments.
* Added a proxy configuration in `frontend/vite.config.js` to direct `/api` requests to the backend server at `http://localhost:3001`, supporting local development without explicit backend URL setup.

**Backend validation enhancements:**

* Modified the `description` field validation in `backend/src/controllers/campaignController.js` to allow `null` and default to an empty string, ensuring consistent campaign data and preventing validation errors for missing descriptions.